### PR TITLE
Pulling in all changes from the dev branch.

### DIFF
--- a/Export-Bitwarden.psm1
+++ b/Export-Bitwarden.psm1
@@ -26,7 +26,7 @@ function Export-Bitwarden { # Don't touch this line!
 		# ====================================================
 
 		Write-Host -ForegroundColor Green "========================================================================================"
-		Write-Host -ForegroundColor Green "==                        Bitwarden Vault Export Script v1.24                         =="
+		Write-Host -ForegroundColor Green "==                        Bitwarden Vault Export Script v1.25                         =="
 		Write-Host -ForegroundColor Green "== Originally created by David H, converted to a Powershell Script by Thomas Parkison =="
 		Write-Host -ForegroundColor Green "==              https://github.com/trparky/Bitwarden-Vault-Export-Script              =="
 		Write-Host -ForegroundColor Green "========================================================================================"

--- a/install-module.ps1
+++ b/install-module.ps1
@@ -13,6 +13,6 @@ else {
 	else {
 		Write-Host "Installing module..." -NoNewLine
 		Add-Content -Path $PROFILE -Value $contentToAppend -Encoding UTF8
-		Write-Host " Done".
+		Write-Host " Done."
 	}
 }

--- a/install-module.ps1
+++ b/install-module.ps1
@@ -22,13 +22,13 @@ else {
 				Write-Host "Module path found, but not correct. Correcting path..." -NoNewline
 				$file_contents = $file_contents -creplace '\$ExportBitwardenScriptPath = "([]\t !"#$%&''()*+,./0-9:;<=>?@A-Z[\\_`a-z{|}~^-]{10,}\.psd1)"', "`$ExportBitwardenScriptPath = ""$path"""
 				$file_contents | Out-File -FilePath $PROFILE -NoNewline
-				Write-Host " Done."
+				Write-Host " Done. You will now have to restart the Powershell shell for the changes to take effect."
 			}
 		}
 	}
 	else {
 		Write-Host "Installing module..." -NoNewLine
 		Add-Content -Path $PROFILE -Value $contentToAppend -Encoding UTF8
-		Write-Host " Done."
+		Write-Host " Done. You will now have to restart the Powershell shell for the changes to take effect."
 	}
 }

--- a/install-module.ps1
+++ b/install-module.ps1
@@ -11,7 +11,21 @@ if (!(Test-Path -Path $PROFILE)) {
 else {
 	$file_contents = Get-Content -Path $PROFILE -Raw
 
-	if ($file_contents.Contains("Export-Bitwarden.psd1")) { Write-Host "Module already installed." }
+	if ($file_contents.Contains("Export-Bitwarden.psd1")) {
+		if ($file_contents -cmatch '\$ExportBitwardenScriptPath = "([]\t !"#$%&''()*+,./0-9:;<=>?@A-Z[\\_`a-z{|}~^-]{10,}\.psd1)"') {
+			$ExportBitwardenScriptPath = $matches[1]
+
+			if ($ExportBitwardenScriptPath.ToLower().Trim() -eq $path.ToLower()) {
+				Write-Host "Module already installed."
+			}
+			else {
+				Write-Host "Module path found, but not correct. Correcting path..." -NoNewline
+				$file_contents = $file_contents -creplace '\$ExportBitwardenScriptPath = "([]\t !"#$%&''()*+,./0-9:;<=>?@A-Z[\\_`a-z{|}~^-]{10,}\.psd1)"', "`$ExportBitwardenScriptPath = ""$path"""
+				$file_contents | Out-File -FilePath $PROFILE -NoNewline
+				Write-Host " Done."
+			}
+		}
+	}
 	else {
 		Write-Host "Installing module..." -NoNewLine
 		Add-Content -Path $PROFILE -Value $contentToAppend -Encoding UTF8

--- a/install-module.ps1
+++ b/install-module.ps1
@@ -3,8 +3,10 @@ $contentToAppend = "`n`$ExportBitwardenScriptPath = ""$path""
 if (Test-Path(`$ExportBitwardenScriptPath)) { Import-Module `$ExportBitwardenScriptPath }"
 
 if (!(Test-Path -Path $PROFILE)) {
+	Write-Host "Installing module..." -NoNewLine
 	New-Item -Path $PROFILE -ItemType File -Force
 	Add-Content -Path $filePath -Value $contentToAppend -Encoding UTF8
+	Write-Host " Done."
 }
 else {
 	$file_contents = Get-Content -Path $PROFILE -Raw

--- a/install-module.ps1
+++ b/install-module.ps1
@@ -1,5 +1,5 @@
-$path = Join-Path (Get-Location) "Export-Bitwarden.psd1"
-$contentToAppend = "`n`$ExportBitwardenScriptPath = ""$path""
+$pathToPSD1File = Join-Path (Get-Location) "Export-Bitwarden.psd1"
+$contentToAppend = "`n`$ExportBitwardenScriptPath = ""$pathToPSD1File""
 if (Test-Path(`$ExportBitwardenScriptPath)) { Import-Module `$ExportBitwardenScriptPath }"
 
 if (!(Test-Path -Path $PROFILE)) {
@@ -15,12 +15,12 @@ else {
 		if ($file_contents -cmatch '\$ExportBitwardenScriptPath = "([]\t !"#$%&''()*+,./0-9:;<=>?@A-Z[\\_`a-z{|}~^-]{10,}\.psd1)"') {
 			$ExportBitwardenScriptPath = $matches[1]
 
-			if ($ExportBitwardenScriptPath.ToLower().Trim() -eq $path.ToLower()) {
+			if ($ExportBitwardenScriptPath.ToLower().Trim() -eq $pathToPSD1File.ToLower()) {
 				Write-Host "Module already installed."
 			}
 			else {
 				Write-Host "Module path found, but not correct. Correcting path..." -NoNewline
-				$file_contents = $file_contents -creplace '\$ExportBitwardenScriptPath = "([]\t !"#$%&''()*+,./0-9:;<=>?@A-Z[\\_`a-z{|}~^-]{10,}\.psd1)"', "`$ExportBitwardenScriptPath = ""$path"""
+				$file_contents = $file_contents -creplace '\$ExportBitwardenScriptPath = "([]\t !"#$%&''()*+,./0-9:;<=>?@A-Z[\\_`a-z{|}~^-]{10,}\.psd1)"', "`$ExportBitwardenScriptPath = ""$pathToPSD1File"""
 				$file_contents | Out-File -FilePath $PROFILE -NoNewline
 				Write-Host " Done. You will now have to restart the Powershell shell for the changes to take effect."
 			}


### PR DESCRIPTION
- Fixed a small text formatting bug in the install module script.
- Forgot to tell the user that we installed the module if the profile file didn't exist and we had to create one.
- Added code to the module installer to check for the correct path and if it detects the wrong path to the PSD1 file, it will correct it for you.
- Added instructions to tell the user that they need to restart Powershell.
- Renamed some variables in the module installer script.