### PR TITLE
Added variable support and much more

### DIFF
--- a/Export-Bitwarden.psd1
+++ b/Export-Bitwarden.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Export-Bitwarden.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.49'
+ModuleVersion = '1.50'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Export-Bitwarden.psm1
+++ b/Export-Bitwarden.psm1
@@ -299,10 +299,11 @@ function Export-Bitwarden { # Don't touch this line!
 			else {
 				$password1Encrypted = ConvertTo-SecureString $encryptPassword -AsPlainText -Force
 			}
-			Write-Host -ForegroundColor Yellow "WARNING!" -NoNewLine
-			Write-Host " Your vault contents will be saved to an unencrypted file."
 		}
 		else {
+			Write-Host -ForegroundColor Yellow "WARNING!" -NoNewLine
+			Write-Host " Your vault contents will be saved to an unencrypted file."
+			
 			if (!$continue) {
 				Write-Host -ForegroundColor Red "ERROR:" -NoNewLine
 				Write-Host " Rerun the script with the -continue option."


### PR DESCRIPTION
Hi,
since I want to schedule this script, I modified it to be able to use environment variables like:

    userEmail
    userPassword
    encryptPassword

if these vars are $null it will ask for them like it did before.

I also removed the AskYesNoQuestion and moved those parameters as argument. To encrypt there's the -encrypt arg, and if you add -encrypt you also have to add the -continue arg otherwise it will exit (same behaviour we had before). To compress I added -compress argument

Now everything can run as batch
